### PR TITLE
Subtracting the buffer from the overall size

### DIFF
--- a/lib/Colgroup.js
+++ b/lib/Colgroup.js
@@ -19,7 +19,7 @@ Colgroup.prototype.parse = function (src) {
   var result
   while ((result = reColumn.exec(src)) !== null) {
     var rule = result[1].trim()
-    var size = result[1].length
+    var size = result[1].length - 2
     if (/^:/.test(rule)) {
       if (/:$/.test(rule)) {
         this.push(new Column(Column.ALIGN_CENTER, size))


### PR DESCRIPTION
Without this change every time you run the script it will cause the table to grow by two character lengths / column.

Great project by the way.